### PR TITLE
Fix setDrawerMaxWidth

### DIFF
--- a/src/com/github/eddieringle/android/libs/undergarment/widgets/DrawerGarment.java
+++ b/src/com/github/eddieringle/android/libs/undergarment/widgets/DrawerGarment.java
@@ -494,6 +494,7 @@ public class DrawerGarment extends FrameLayout {
      */
     public void setDrawerMaxWidth(final int maxWidth) {
         mDrawerMaxWidth = maxWidth;
+        reconfigureViewHierarchy();
     }
 
     public int getDrawerMaxWidth() {


### PR DESCRIPTION
Unless I'm doing something wrong, setDrawerMaxWidth doesn't work unless I add this call to reconfigureViewHierarchy();
